### PR TITLE
Missing asset type id, improve asset retrieval and inverted param order

### DIFF
--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -162,6 +162,7 @@ class Asset extends MetadataType {
         } else {
             Util.logger.info(`- Caching Subtype: ${subType}`);
         }
+        const subtypeIds = subTypeArray?.map(subTypeItemName => Asset.definition.typeMapping[subTypeItemName]);
         const uri = 'asset/v1/content/assets/';
         const options = {
             uri: uri + 'query',
@@ -178,9 +179,9 @@ class Asset extends MetadataType {
         if (templateName) {
             options.json.query = {
                 leftOperand: {
-                    property: 'assetType.name',
+                    property: 'assetType.id',
                     simpleOperator: 'in',
-                    value: subTypeArray,
+                    value: subtypeIds,
                 },
                 logicalOperator: 'AND',
                 rightOperand: {
@@ -191,9 +192,9 @@ class Asset extends MetadataType {
             };
         } else {
             options.json.query = {
-                property: 'assetType.name',
+                property: 'assetType.id',
                 simpleOperator: 'in',
-                value: subTypeArray,
+                value: subtypeIds,
             };
             options.json.sort = [{ property: 'id', direction: 'ASC' }];
         }
@@ -232,9 +233,9 @@ class Asset extends MetadataType {
                 // Since we sort by ID, we can get the last ID then run new requests from there
                 options.json.query = {
                     leftOperand: {
-                        property: 'assetType.name',
+                        property: 'assetType.id',
                         simpleOperator: 'in',
-                        value: subTypeArray,
+                        value: subtypeIds,
                     },
                     logicalOperator: 'AND',
                     rightOperand: {
@@ -441,7 +442,7 @@ class Asset extends MetadataType {
         await this._mergeCode(metadata, deployDir, subType);
 
         // #2 get file from local disk and insert as base64
-        await this._readExtendedFileFromFS(metadata, deployDir, subType);
+        await this._readExtendedFileFromFS(metadata, subType, deployDir);
 
         return metadata;
     }

--- a/lib/metadataTypes/definitions/Asset.definition.js
+++ b/lib/metadataTypes/definitions/Asset.definition.js
@@ -677,6 +677,7 @@ module.exports = {
         ],
     },
     typeMapping: {
+        ai: 16,
         psd: 17,
         pdd: 18,
         eps: 19,


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [ x] Bug fix
- [x ] Enhanced metadata

## What changes did you make? (Give an overview)

- Asset.definition was missing typeMapping entry for .ai
- Method Asset._readExtendedFileFromFS was being called with wrong parameters order
- Changed the filter in Asset to use type ids instead of type names, which solves the 10k limit at the source.

## Is there anything you'd like reviewers to focus on?

Not really. I only have a note about the way the code was supposed to overcome the 10k limit before I changed the filter.
It did not allow me to retrieve more than 10k, hence this pull request.
But I have an app that use this API in a similar manner, so I knew there was no 10k limit when using type ids.

Maybe you would like to rewrite this part of the code since the first 'if' should never be true anymore?

`lib\metadataTypes\Asset.js:231`

```
if (response.body.message && response.body.message.includes('all shards failed')) {
    // When running certain filters, there is a limit of 10k on ElastiCache.
    // Since we sort by ID, we can get the last ID then run new requests from there
    options.json.query = {
        leftOperand: {
            property: 'assetType.id',
            simpleOperator: 'in',
            value: subtypeIds,
        },
        logicalOperator: 'AND',
        rightOperand: {
            property: 'id',
            simpleOperator: 'greaterThan',
            value: items[items.length - 1].id,
        },
    };
    lastPage = 0;
    moreResults = true;
} else if (response.body.page * response.body.pageSize < response.body.count) {
    moreResults = true;
    lastPage = Number(response.body.page);
} else {
    moreResults = false;
}
```

## Checklist

- [ x] I have performed a self-review of my own code
