### PR TITLE
add object name to activities in automations

### DIFF
--- a/lib/metadataTypes/Automation.js
+++ b/lib/metadataTypes/Automation.js
@@ -593,6 +593,11 @@ class Automation extends MetadataType {
                                         Definitions[activity.r__type].idField,
                                         Definitions[activity.r__type].nameField
                                     );
+                                    const nameField = Definitions[
+                                        activity.r__type
+                                    ].nameField.toLowerCase();
+                                    activity[`r__activityObject_${nameField}`] =
+                                        activity.activityObjectId;
                                 } catch (e) {
                                     // getFromCache throws error where the dependent metadata is not found
                                     Util.logger.error(

--- a/lib/metadataTypes/definitions/Automation.definition.js
+++ b/lib/metadataTypes/definitions/Automation.definition.js
@@ -511,6 +511,9 @@ module.exports = {
         'steps[].activities[].r__type': {
             skipValidation: true,
         },
+        'steps[].activities[].r__activityObject_name': {
+            skipValidation: true,
+        },
         'steps[].description': {
             isCreateable: true,
             isUpdateable: true,


### PR DESCRIPTION
Keep real activity names in automations (r__activityObject_<lowercase-name-field>).